### PR TITLE
registryctl issue #1: fix registry_config not defined in the registryctl config

### DIFF
--- a/2/debian-10/config/registryctl/config.yml
+++ b/2/debian-10/config/registryctl/config.yml
@@ -2,6 +2,7 @@
 protocol: "http"
 port: 8080
 log_level: "INFO"
+registry_config: "/etc/registry/config.yml"
 
 #https_config:
 #  cert: "server.crt"


### PR DESCRIPTION
Docker-compose deployed without "registry_config" property results in following error:

```
[ERROR] [/registryctl/config/config.go:63]: failed to load storage driver, err:open : no such file or directory
[FATAL] [/registryctl/main.go:78]: Failed to load configurations with error: open : no such file or directory
```

See harbor v2.1.2 registryctl Configuration data-structure for reference: [link](https://github.com/goharbor/harbor/blob/fcc6751d5439da1b58f2553cb49b7db9bc3ad17a/src/registryctl/config/config.go#L41)
