### PR TITLE
modified config link

### DIFF
--- a/config
+++ b/config
@@ -1,1 +1,1 @@
-2/debian-10/config
+2/debian-11/config


### PR DESCRIPTION
Hi!
at https://github.com/bitnami/bitnami-docker-harbor-portal/archive/master.tar.gz, file "config" must be link to "2/debian-11/config" but is it "2/debian-10/config"

What is the expected behavior?
config -> 2/debian-11/config

What do you see instead?
config -> 2/debian-10/config